### PR TITLE
.gitignore some more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 MANIFEST
 dist/
 build/
-
+/xflux
+/installed.txt


### PR DESCRIPTION
The downloaded `xflux` binary and the generated `installed.txt` manifest should be ignored to avoid accidentally running Git operations on them.