### PR TITLE
Fix autostart behaviour when not installed system-wide

### DIFF
--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import gconf
 from xdg.DesktopEntry import DesktopEntry
 from fluxgui.exceptions import DirectoryCreationError
@@ -158,7 +159,7 @@ class Settings(object):
             #create autostart entry
             starter_item = DesktopEntry(autostart_file)
             starter_item.set('Name', 'f.lux indicator applet')
-            starter_item.set('Exec', 'fluxgui')
+            starter_item.set('Exec', os.path.realpath(sys.argv[0]))
             starter_item.set('Icon', 'fluxgui')
             starter_item.set('X-GNOME-Autostart-enabled', 'true')
             starter_item.write()

--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -159,6 +159,7 @@ class Settings(object):
             #create autostart entry
             starter_item = DesktopEntry(autostart_file)
             starter_item.set('Name', 'f.lux indicator applet')
+            starter_item.set('Comment', 'Better lighting for your computer')
             starter_item.set('Exec', os.path.realpath(sys.argv[0]))
             starter_item.set('Icon', 'fluxgui')
             starter_item.set('X-GNOME-Autostart-enabled', 'true')


### PR DESCRIPTION
When fluxgui is not installed system-wide, the autostart .desktop file
does not work:

* $PATH is used to evaluate the `fluxgui` command but not any
  modifications the user makes to it in their initialisation
  scripts (e.g. adding `~/.local/bin`). The Exec command therefore
  fails. With this patch, the field contains the path to used to start
  the current instance.
* fluxgui also expects `xflux` to be in $PATH. The same problem occurs
  as above and fluxgui fails to run because it cannot execute
  `xflux`. With this patch, there is a fallback search for `xflux` in
  the same directory as the executable for the current instance. This
  would be the normal way fluxgui is installed.

Additionally, the Comment field is added to the launcher since this is
shown in the Startup Applications GUI.