### PR TITLE
fluxgui GTK+ 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ git clone "https://github.com/xflux-gui/fluxgui.git"
 cd fluxgui
 ./download-xflux.py
 
+# Compile GLIB schemas (temporary workaround until setup.py is fixed)
+glib-compile-schemas .
+
 # EITHER install system wide
 sudo ./setup.py install --record installed.txt
 xargs sudo chmod -R a+rX < installed.txt
@@ -82,10 +85,10 @@ xargs sudo chmod -R a+rX < installed.txt
 # into ~/.local/bin, so be sure to add that to your PATH if installing
 # locally. In particular, autostarting fluxgui in Gnome will not work
 # if the locally installed fluxgui is not on your PATH.
-./setup.py install --user
+./setup.py install --user --record installed.txt
        
-# Run flux
-fluxgui
+# Run flux (the GSETTINGS_SCHEMA_DIR is temporary until setup.py is updated)
+GSETTINGS_SCHEMA_DIR=. fluxgui
 ```
 
 ### Manual Uninstall

--- a/README.md
+++ b/README.md
@@ -53,11 +53,15 @@ To install manually you first install the dependencies using your package manage
 
 ##### Ubuntu/Debian
 
+WARNING: these dependencies may be out of date after the uprgrade to GTK+ 3 in PR #112. If you discover the correct deps, please submit a PR.
+
 ```bash
-sudo apt-get install git python-appindicator python-xdg python-pexpect python-gconf python-gtk2 python-glade2 libxxf86vm1
+sudo apt-get install git python-appindicator python-xdg python-pexpect python-gconf python-gtk2 python-glade2 libxxf86vm1 gir1.2-appindicator3-0.1
 ```
 
 ##### Fedora/CentOS
+
+WARNING: these dependencies may be out of date after the uprgrade to GTK+ 3 in PR #112. If you discover the correct deps, please submit a PR.
 
 ```bash
 sudo yum install git python-appindicator python2-pyxdg python2-pexpect gnome-python2-gconf pygtk2 pygtk2-libglade

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You can also easily configure the applet to auto-start on login.
 Install Instructions
 --------------------
 
-### Only Python 2 is Supported
+### Only Python 3 is Supported
 
-The `fluxgui` is only known to work with Python 2, so use `python2` instead of `python` for the commands in this README if Python 3 is the default on your system.
+The `fluxgui` is only known to work with Python 3.
 
 ### Ubuntu PPA Package Manager Install
 
@@ -71,16 +71,16 @@ There are separate instructions in the code below for installing system wide and
 cd /tmp
 git clone "https://github.com/xflux-gui/fluxgui.git"
 cd fluxgui
-python download-xflux.py
+./download-xflux.py
 
 # EITHER install system wide
-sudo python setup.py install
+sudo ./setup.py install
 
 # EXCLUSIVE OR, install in your home directory. The binary installs
 # into ~/.local/bin, so be sure to add that to your PATH if installing
 # locally. In particular, autostarting fluxgui in Gnome will not work
 # if the locally installed fluxgui is not on your PATH.
-python setup.py install --user
+./setup.py install --user
        
 # Run flux
 fluxgui
@@ -94,11 +94,11 @@ removing the installed files.
 
 ```bash
 # EITHER uninstall globally
-sudo python setup.py install --record installed.txt
+sudo ./setup.py install --record installed.txt
 sudo xargs rm -vr < installed.txt
 
 # EXCLUSIVE OR uninstall in your home directory
-python setup.py install --user --record installed.txt
+./setup.py install --user --record installed.txt
 xargs rm -vr < installed.txt
 ```
 
@@ -116,8 +116,9 @@ When working on `fluxgui`, you can use
 ```bash
 cd <path to your fluxgui.git clone>
 # You only need to download xflux once.
-python download-xflux.py
-PATH=`pwd`:$PATH PYTHONPATH=`pwd`/src:$PYTHONPATH ./fluxgui &
+./download-xflux.py
+glib-compile-schemas .
+GSETTINGS_SCHEMA_DIR=`pwd` PATH=`pwd`:$PATH PYTHONPATH=`pwd`/src:$PYTHONPATH ./fluxgui
 ```
 to test your local copy of `fluxgui` without installing anything.
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,21 @@ cd fluxgui
 glib-compile-schemas .
 
 # EITHER install system wide
-sudo ./setup.py install --record installed.txt
+#
+# Perhaps we're using setup.py incorrectly, but I'd expect it to create
+# files with permissions for regular users to access them, but it does
+# not. The 'umask 000' is necessary because otherwise setup.py will create
+# unreadable directories that aren't included in the installed.txt, e.g.
+#
+# /usr/local/share/icons
+# /usr/local/share/applications
+# /usr/local/lib/python3.5/dist-packages/fluxgui
+sudo sh -c 'umask 000 && ./setup.py install --record installed.txt'
 xargs sudo chmod -R a+rX < installed.txt
 
-# EXCLUSIVE OR, install in your home directory. The binary installs
+# EXCLUSIVE OR, install in your home directory
+#
+# The fluxgui program installs
 # into ~/.local/bin, so be sure to add that to your PATH if installing
 # locally. In particular, autostarting fluxgui in Gnome will not work
 # if the locally installed fluxgui is not on your PATH.

--- a/README.md
+++ b/README.md
@@ -74,21 +74,8 @@ git clone "https://github.com/xflux-gui/fluxgui.git"
 cd fluxgui
 ./download-xflux.py
 
-# Compile GLIB schemas (temporary workaround until setup.py is fixed)
-glib-compile-schemas .
-
 # EITHER install system wide
-#
-# Perhaps we're using setup.py incorrectly, but I'd expect it to create
-# files with permissions for regular users to access them, but it does
-# not. The 'umask 000' is necessary because otherwise setup.py will create
-# unreadable directories that aren't included in the installed.txt, e.g.
-#
-# /usr/local/share/icons
-# /usr/local/share/applications
-# /usr/local/lib/python3.5/dist-packages/fluxgui
-sudo sh -c 'umask 000 && ./setup.py install --record installed.txt'
-xargs sudo chmod -R a+rX < installed.txt
+sudo ./setup.py install --record installed.txt
 
 # EXCLUSIVE OR, install in your home directory
 #
@@ -98,8 +85,8 @@ xargs sudo chmod -R a+rX < installed.txt
 # if the locally installed fluxgui is not on your PATH.
 ./setup.py install --user --record installed.txt
        
-# Run flux (the GSETTINGS_SCHEMA_DIR is temporary until setup.py is updated)
-GSETTINGS_SCHEMA_DIR=. fluxgui
+# Run flux
+fluxgui
 ```
 
 ### Manual Uninstall

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To install manually you first install the dependencies using your package manage
 ```bash
 sudo apt-get install git python-appindicator python-xdg python-pexpect python-gconf python-gtk2 python-glade2 libxxf86vm1
 ```
+
 ##### Fedora/CentOS
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -110,12 +110,15 @@ removing the installed files.
 
 ```bash
 # EITHER uninstall globally
-sudo ./setup.py install --record installed.txt
+#
+# The 'installed.txt' is generated when you install. Reinstall first if you
+# as described above if you don't have an 'installed.txt' file.
 sudo xargs rm -vr < installed.txt
+sudo glib-compile-schemas "$(dirname "$(grep apps.fluxgui.gschema.xml installed.txt)")"
 
 # EXCLUSIVE OR uninstall in your home directory
-./setup.py install --user --record installed.txt
 xargs rm -vr < installed.txt
+glib-compile-schemas "$(dirname "$(grep apps.fluxgui.gschema.xml installed.txt)")"
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ cd fluxgui
 ./download-xflux.py
 
 # EITHER install system wide
-sudo ./setup.py install
+sudo ./setup.py install --record installed.txt
+xargs sudo chmod -R a+rX < installed.txt
 
 # EXCLUSIVE OR, install in your home directory. The binary installs
 # into ~/.local/bin, so be sure to add that to your PATH if installing

--- a/apps.fluxgui.gschema.xml
+++ b/apps.fluxgui.gschema.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="apps.fluxgui" path="/apps/fluxgui/">
+    <key type="b" name="autostart">
+      <default>false</default>
+      <summary>Autostart</summary>
+      <description>If set True the application start with the system.</description>
+    </key>
+
+    <key type="s" name="colortemp">
+        <default>'3400'</default>
+        <summary>Colortemp</summary>
+        <description></description>
+    </key>
+
+    <key type="s" name="latitude">
+        <default>'0'</default>
+        <summary>Latitude</summary>
+        <description>Latitude of the user.</description>
+    </key>
+
+    <key type="s" name="longitude">
+        <default>'0'</default>
+        <summary>Longitude</summary>
+        <description>Longitude of the user.</description>
+    </key>
+
+    <key type="s" name="zipcode">
+        <default>'0'</default>
+        <summary>Zipcode</summary>
+        <description>Zipcode of the user.</description>
+    </key>
+  </schema>
+</schemalist>

--- a/apps.fluxgui.gschema.xml
+++ b/apps.fluxgui.gschema.xml
@@ -14,19 +14,19 @@
     </key>
 
     <key type="s" name="latitude">
-        <default>'0'</default>
+        <default>''</default>
         <summary>Latitude</summary>
         <description>Latitude of the user.</description>
     </key>
 
     <key type="s" name="longitude">
-        <default>'0'</default>
+        <default>''</default>
         <summary>Longitude</summary>
         <description>Longitude of the user.</description>
     </key>
 
     <key type="s" name="zipcode">
-        <default>'90210'</default>
+        <default>''</default>
         <summary>Zipcode</summary>
         <description>Zipcode of the user.</description>
     </key>

--- a/apps.fluxgui.gschema.xml
+++ b/apps.fluxgui.gschema.xml
@@ -26,7 +26,7 @@
     </key>
 
     <key type="s" name="zipcode">
-        <default>'0'</default>
+        <default>'90210'</default>
         <summary>Zipcode</summary>
         <description>Zipcode of the user.</description>
     </key>

--- a/fluxgui
+++ b/fluxgui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #coding: utf-8
 #
 #Copyright (c) 2010 Michael and Lorna Herf, Kilian Valkhof

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 import os

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,22 @@ from distutils.log import info
 import distutils.command.install_data
 import os, subprocess
 
+# Set an appropriate umask for global installs. The 'setup.py' install
+# respects the umask, even if it results in files only root can read
+# in a global install :P
+os.umask(0o022)
+
+# Set appropriate permissions on all local files in the repo. The
+# 'setup.py' install preserves permissions on copied files, which
+# creates problems for global installs :P
+#
+# There is a fancier solution at
+# https://stackoverflow.com/a/25761434/470844 that uses
+# 'self.get_outputs()' in a custom 'distutils.command.install'
+# subclass to only modify permissions of files that 'setup.py'
+# installed.
+subprocess.call(['chmod', '-R', 'a+rX', '.'])
+
 # On Ubuntu 18.04 both '/usr/local/share/glib-2.0/schemas' (global
 # install) and '~/.local/share/glib-2.0/schemas' (local '--user'
 # install) are on the default search path for glib schemas. The global

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from distutils.core import setup
-import os
+import os, subprocess
 
 data_files = [
     ('share/icons/hicolor/16x16/apps', ['icons/hicolor/16x16/apps/fluxgui.svg']),
@@ -26,14 +26,19 @@ data_files = [
     ('share/applications', ['desktop/fluxgui.desktop'])]
 
 scripts = ['fluxgui']
+
 if (os.path.exists("xflux")):
-    scripts.append('xflux')
+    # Unlike for 'scripts', the 'setup.py' doesn't modify the
+    # permissions on files installed using 'data_files', so we need to
+    # set the permissions ourselves.
+    subprocess.call(['chmod', 'a+rx', 'xflux'])
+    data_files.append(('bin', ['xflux']))
 else:
     print("""WARNING: if you are running 'python setup.py' manually, and not as
 part of Debian package creation, then you need to download the 'xflux'
 binary separately. You can do this by running
 
-    python ./download-xflux.py
+    ./download-xflux.py
 
 before running 'setup.py'.""")
 

--- a/src/fluxgui/exceptions.py
+++ b/src/fluxgui/exceptions.py
@@ -1,18 +1,22 @@
 __all__ = ['DirectoryCreationError', 'FileNotFoundError',
-        'XfluxError', 'MethodUnavailableError']
+           'XfluxError', 'MethodUnavailableError']
+
 
 class Error(Exception):
     pass
 
+
 class DirectoryCreationError(Error):
     pass
+
 
 class FileNotFoundError(Error):
     pass
 
+
 class XfluxError(Error):
     pass
 
+
 class MethodUnavailableError(Error):
     pass
-

--- a/src/fluxgui/exceptions.py
+++ b/src/fluxgui/exceptions.py
@@ -1,22 +1,17 @@
 __all__ = ['DirectoryCreationError', 'FileNotFoundError',
-           'XfluxError', 'MethodUnavailableError']
-
+        'XfluxError', 'MethodUnavailableError']
 
 class Error(Exception):
     pass
 
-
 class DirectoryCreationError(Error):
     pass
-
 
 class FileNotFoundError(Error):
     pass
 
-
 class XfluxError(Error):
     pass
-
 
 class MethodUnavailableError(Error):
     pass

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -1,14 +1,15 @@
 #!/usr/bin/python
 
+from fluxgui.exceptions import MethodUnavailableError
+from fluxgui import fluxcontroller, settings
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk as gtk
+gi.require_version('AppIndicator3', '0.1')
+from gi.repository import AppIndicator3 as appindicator
 import signal
 import os
 import sys
-import gi
-gi.require_version('Gtk', '3.0')
-from gi.repository import AppIndicator3 as appindicator
-from gi.repository import Gtk as gtk
-from fluxgui import fluxcontroller, settings
-from fluxgui.exceptions import MethodUnavailableError
 
 
 class FluxGUI(object):
@@ -77,9 +78,9 @@ class Indicator(object):
     def create_menu(self):
         menu = gtk.Menu()
 
-        self.add_menu_item("_Pause f.lux", self._toggle_pause,
+        self.add_menu_item("Pause f.lux", self._toggle_pause,
                            menu, MenuItem=gtk.CheckMenuItem)
-        self.add_menu_item("Prefere_nces", self._open_preferences, menu)
+        self.add_menu_item("Preferences", self._open_preferences, menu)
         self.add_menu_separator(menu)
         self.add_menu_item("Quit", self._quit, menu)
 
@@ -147,6 +148,7 @@ class Preferences(object):
                                                self.delete_event, "clicked")
         self.autostart = self.connect_widget("checkAutostart")
 
+        # TODO: Fix this bug
         if (self.settings.latitude is "" and self.settings.zipcode is "")\
                 or not self.settings.has_set_prefs:
             self.show()
@@ -168,11 +170,11 @@ class Preferences(object):
 
     def display_no_zipcode_or_latitude_error_box(self):
         md = gtk.MessageDialog(self.window,
-                               gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO,
-                               gtk.BUTTONS_OK, ("The f.lux indicator applet needs to know "
-                                                "your latitude or zipcode to run. "
-                                                "Please fill either of them in on "
-                                                "the preferences screen and click 'Close'."))
+                               gtk.DialogFlags.DESTROY_WITH_PARENT, gtk.MessageType.INFO,
+                               gtk.ButtonsType.OK, ("The f.lux indicator applet needs to know "
+                                                    "your latitude or zipcode to run. "
+                                                    "Please fill either of them in on "
+                                                    "the preferences screen and click 'Close'."))
         md.set_title("f.lux indicator applet")
         md.run()
         md.destroy()

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -1,13 +1,14 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 
 from fluxgui import fluxcontroller, settings
 from fluxgui.exceptions import MethodUnavailableError
-import gtk
-import gtk.glade
-import appindicator
-import sys, os
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk as gtk
+from gi.repository import AppIndicator3 as appindicator
+import sys
+import os
 import signal
-import errno
 
 class FluxGUI(object):
     """
@@ -23,8 +24,8 @@ class FluxGUI(object):
             self.xflux_controller.start()
 
         except Exception as e:
-            print e
-            print "Critical error. Exiting."
+            print(e)
+            print("Critical error. Exiting.")
             self.exit(1)
 
     def __del__(self):
@@ -34,8 +35,8 @@ class FluxGUI(object):
         self.preferences.show()
 
     def signal_exit(self, signum, frame):
-        print 'Received signal: ', signum
-        print 'Quitting...'
+        print('Received signal: ', signum)
+        print('Quitting...')
         self.exit()
 
     def exit(self, code=0):
@@ -58,15 +59,15 @@ class Indicator(object):
     def __init__(self, fluxgui, xflux_controller):
         self.fluxgui = fluxgui
         self.xflux_controller = xflux_controller
-        self.indicator = appindicator.Indicator(
+        self.indicator = appindicator.Indicator.new(
           "fluxgui-indicator",
           "fluxgui",
-          appindicator.CATEGORY_APPLICATION_STATUS)
+          appindicator.IndicatorCategory.APPLICATION_STATUS)
 
         self.setup_indicator()
 
     def setup_indicator(self):
-        self.indicator.set_status(appindicator.STATUS_ACTIVE)
+        self.indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
         self.indicator.set_icon('fluxgui-panel')
         self.indicator.set_menu(self.create_menu())
 
@@ -114,7 +115,7 @@ class Preferences(object):
 
     def connect_widget(self, widget_name, connect_target=None,
             connect_event="activate"):
-        widget = self.wTree.get_widget(widget_name)
+        widget = self.wTree.get_object(widget_name)
         if connect_target:
             widget.connect(connect_event, connect_target)
         return widget
@@ -126,7 +127,7 @@ class Preferences(object):
 
         self.gladefile = os.path.join(os.path.dirname(os.path.dirname(
           os.path.realpath(__file__))), "fluxgui/preferences.glade")
-        self.wTree = gtk.glade.XML(self.gladefile)
+        self.wTree = Gtk.Builder.new_from_file(self.gladefile)
 
         self.window = self.connect_widget("window1", self.delete_event,
                 connect_event="destroy")

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -1,26 +1,28 @@
 #!/usr/bin/python
 
-from fluxgui import fluxcontroller, settings
-from fluxgui.exceptions import MethodUnavailableError
+import signal
+import os
+import sys
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk as gtk
 from gi.repository import AppIndicator3 as appindicator
-import sys
-import os
-import signal
+from gi.repository import Gtk as gtk
+from fluxgui import fluxcontroller, settings
+from fluxgui.exceptions import MethodUnavailableError
+
 
 class FluxGUI(object):
     """
     FluxGUI initializes/destroys the app
     """
+
     def __init__(self):
         try:
             self.settings = settings.Settings()
             self.xflux_controller = fluxcontroller.FluxController(self.settings)
             self.indicator = Indicator(self, self.xflux_controller)
             self.preferences = Preferences(self.settings,
-                    self.xflux_controller)
+                                           self.xflux_controller)
             self.xflux_controller.start()
 
         except Exception as e:
@@ -50,6 +52,7 @@ class FluxGUI(object):
     def run(self):
         gtk.main()
 
+
 class Indicator(object):
     """
     Information and methods related to the indicator applet.
@@ -60,9 +63,9 @@ class Indicator(object):
         self.fluxgui = fluxgui
         self.xflux_controller = xflux_controller
         self.indicator = appindicator.Indicator.new(
-          "fluxgui-indicator",
-          "fluxgui",
-          appindicator.IndicatorCategory.APPLICATION_STATUS)
+            "fluxgui-indicator",
+            "fluxgui",
+            appindicator.IndicatorCategory.APPLICATION_STATUS)
 
         self.setup_indicator()
 
@@ -75,7 +78,7 @@ class Indicator(object):
         menu = gtk.Menu()
 
         self.add_menu_item("_Pause f.lux", self._toggle_pause,
-                menu, MenuItem=gtk.CheckMenuItem)
+                           menu, MenuItem=gtk.CheckMenuItem)
         self.add_menu_item("Prefere_nces", self._open_preferences, menu)
         self.add_menu_separator(menu)
         self.add_menu_item("Quit", self._quit, menu)
@@ -83,7 +86,7 @@ class Indicator(object):
         return menu
 
     def add_menu_item(self, label, handler, menu,
-            event="activate", MenuItem=gtk.MenuItem, show=True):
+                      event="activate", MenuItem=gtk.MenuItem, show=True):
         item = MenuItem(label)
         item.connect(event, handler)
         menu.append(item)
@@ -101,10 +104,11 @@ class Indicator(object):
         self.xflux_controller.toggle_pause()
 
     def _open_preferences(self, item):
-            self.fluxgui.open_preferences()
+        self.fluxgui.open_preferences()
 
     def _quit(self, item):
         self.fluxgui.exit()
+
 
 class Preferences(object):
     """
@@ -114,34 +118,33 @@ class Preferences(object):
     """
 
     def connect_widget(self, widget_name, connect_target=None,
-            connect_event="activate"):
+                       connect_event="activate"):
         widget = self.wTree.get_object(widget_name)
         if connect_target:
             widget.connect(connect_event, connect_target)
         return widget
-
 
     def __init__(self, settings, xflux_controller):
         self.settings = settings
         self.xflux_controller = xflux_controller
 
         self.gladefile = os.path.join(os.path.dirname(os.path.dirname(
-          os.path.realpath(__file__))), "fluxgui/preferences.glade")
-        self.wTree = Gtk.Builder.new_from_file(self.gladefile)
+            os.path.realpath(__file__))), "fluxgui/preferences.glade")
+        self.wTree = gtk.Builder.new_from_file(self.gladefile)
 
         self.window = self.connect_widget("window1", self.delete_event,
-                connect_event="destroy")
+                                          connect_event="destroy")
         self.latsetting = self.connect_widget("entryLatitude",
-                self.delete_event)
+                                              self.delete_event)
         self.lonsetting = self.connect_widget("entryLongitude",
-                self.delete_event)
+                                              self.delete_event)
         self.zipsetting = self.connect_widget("entryZipcode",
-                self.delete_event)
+                                              self.delete_event)
         self.colsetting = self.connect_widget("comboColor")
         self.previewbutton = self.connect_widget("buttonPreview",
-                self.preview_click_event, "clicked")
+                                                 self.preview_click_event, "clicked")
         self.closebutton = self.connect_widget("buttonClose",
-                self.delete_event, "clicked")
+                                               self.delete_event, "clicked")
         self.autostart = self.connect_widget("checkAutostart")
 
         if (self.settings.latitude is "" and self.settings.zipcode is "")\
@@ -165,11 +168,11 @@ class Preferences(object):
 
     def display_no_zipcode_or_latitude_error_box(self):
         md = gtk.MessageDialog(self.window,
-                gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO,
-                gtk.BUTTONS_OK, "The f.lux indicator applet needs to know " +
-                "your latitude or zipcode to run. " +
-                "Please fill either of them in on the preferences screen "+
-                "and click 'Close'.")
+                               gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO,
+                               gtk.BUTTONS_OK, ("The f.lux indicator applet needs to know "
+                                                "your latitude or zipcode to run. "
+                                                "Please fill either of them in on "
+                                                "the preferences screen and click 'Close'."))
         md.set_title("f.lux indicator applet")
         md.run()
         md.destroy()
@@ -182,18 +185,18 @@ class Preferences(object):
     def delete_event(self, widget, data=None):
         if self.settings.latitude != self.latsetting.get_text():
             self.xflux_controller.set_xflux_latitude(
-                    self.latsetting.get_text())
+                self.latsetting.get_text())
 
         if self.settings.longitude != self.lonsetting.get_text():
             self.xflux_controller.set_xflux_longitude(
-                    self.lonsetting.get_text())
+                self.lonsetting.get_text())
 
         if self.settings.zipcode != self.zipsetting.get_text():
             self.xflux_controller.set_xflux_zipcode(
-                    self.zipsetting.get_text())
+                self.zipsetting.get_text())
 
         colsetting_temperature = settings.key_to_temperature(
-                self.colsetting.get_active())
+            self.colsetting.get_active())
         if self.settings.color != colsetting_temperature:
             self.xflux_controller.color = colsetting_temperature
 
@@ -209,6 +212,7 @@ class Preferences(object):
         self.window.hide()
         return False
 
+
 def main():
     try:
         app = FluxGUI()
@@ -219,6 +223,7 @@ def main():
         # No idea why we consistently get a keyboard interrupt here
         # after killing fluxgui with SIGINT or SIGTERM ...
         pass
+
 
 if __name__ == '__main__':
     main()

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -23,7 +23,7 @@ class FluxGUI(object):
             self.xflux_controller = fluxcontroller.FluxController(self.settings)
             self.indicator = Indicator(self, self.xflux_controller)
             self.preferences = Preferences(self.settings,
-                                           self.xflux_controller)
+                    self.xflux_controller)
             self.xflux_controller.start()
 
         except Exception as e:
@@ -79,7 +79,7 @@ class Indicator(object):
         menu = gtk.Menu()
 
         self.add_menu_item("Pause f.lux", self._toggle_pause,
-                           menu, MenuItem=gtk.CheckMenuItem)
+                menu, MenuItem=gtk.CheckMenuItem)
         self.add_menu_item("Preferences", self._open_preferences, menu)
         self.add_menu_separator(menu)
         self.add_menu_item("Quit", self._quit, menu)
@@ -87,7 +87,7 @@ class Indicator(object):
         return menu
 
     def add_menu_item(self, label, handler, menu,
-                      event="activate", MenuItem=gtk.MenuItem, show=True):
+            event="activate", MenuItem=gtk.MenuItem, show=True):
         item = MenuItem(label)
         item.connect(event, handler)
         menu.append(item)
@@ -119,7 +119,7 @@ class Preferences(object):
     """
 
     def connect_widget(self, widget_name, connect_target=None,
-                       connect_event="activate"):
+            connect_event="activate"):
         widget = self.wTree.get_object(widget_name)
         if connect_target:
             widget.connect(connect_event, connect_target)
@@ -130,25 +130,24 @@ class Preferences(object):
         self.xflux_controller = xflux_controller
 
         self.gladefile = os.path.join(os.path.dirname(os.path.dirname(
-            os.path.realpath(__file__))), "fluxgui/preferences.glade")
+          os.path.realpath(__file__))), "fluxgui/preferences.glade")
         self.wTree = gtk.Builder.new_from_file(self.gladefile)
 
         self.window = self.connect_widget("window1", self.delete_event,
-                                          connect_event="destroy")
+                connect_event="destroy")
         self.latsetting = self.connect_widget("entryLatitude",
-                                              self.delete_event)
+                self.delete_event)
         self.lonsetting = self.connect_widget("entryLongitude",
-                                              self.delete_event)
+                self.delete_event)
         self.zipsetting = self.connect_widget("entryZipcode",
-                                              self.delete_event)
+                self.delete_event)
         self.colsetting = self.connect_widget("comboColor")
         self.previewbutton = self.connect_widget("buttonPreview",
-                                                 self.preview_click_event, "clicked")
+                self.preview_click_event, "clicked")
         self.closebutton = self.connect_widget("buttonClose",
-                                               self.delete_event, "clicked")
+                self.delete_event, "clicked")
         self.autostart = self.connect_widget("checkAutostart")
 
-        # TODO: Fix this bug
         if (self.settings.latitude is "" and self.settings.zipcode is "")\
                 or not self.settings.has_set_prefs:
             self.show()
@@ -170,34 +169,35 @@ class Preferences(object):
 
     def display_no_zipcode_or_latitude_error_box(self):
         md = gtk.MessageDialog(self.window,
-                               gtk.DialogFlags.DESTROY_WITH_PARENT, gtk.MessageType.INFO,
-                               gtk.ButtonsType.OK, ("The f.lux indicator applet needs to know "
-                                                    "your latitude or zipcode to run. "
-                                                    "Please fill either of them in on "
-                                                    "the preferences screen and click 'Close'."))
+                gtk.DialogFlags.DESTROY_WITH_PARENT, gtk.MessageType.INFO,
+                gtk.ButtonsType.OK, ("The f.lux indicator applet needs to know "
+                "your latitude or zipcode to run. "
+                "Please fill either of them in on "
+                "the preferences screen and click 'Close'."))
         md.set_title("f.lux indicator applet")
         md.run()
         md.destroy()
 
     def preview_click_event(self, widget, data=None):
-        colsetting_temperature = settings.key_to_temperature(self.colsetting.get_active())
+        colsetting_temperature = settings.key_to_temperature(
+            self.colsetting.get_active())
         self.xflux_controller.preview_color(colsetting_temperature)
 
     def delete_event(self, widget, data=None):
         if self.settings.latitude != self.latsetting.get_text():
             self.xflux_controller.set_xflux_latitude(
-                self.latsetting.get_text())
+                    self.latsetting.get_text())
 
         if self.settings.longitude != self.lonsetting.get_text():
             self.xflux_controller.set_xflux_longitude(
-                self.lonsetting.get_text())
+                    self.lonsetting.get_text())
 
         if self.settings.zipcode != self.zipsetting.get_text():
             self.xflux_controller.set_xflux_zipcode(
-                self.zipsetting.get_text())
+                    self.zipsetting.get_text())
 
         colsetting_temperature = settings.key_to_temperature(
-            self.colsetting.get_active())
+                self.colsetting.get_active())
         if self.settings.color != colsetting_temperature:
             self.xflux_controller.color = colsetting_temperature
 

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -16,7 +16,6 @@ class FluxGUI(object):
     """
     FluxGUI initializes/destroys the app
     """
-
     def __init__(self):
         try:
             self.settings = settings.Settings()
@@ -52,7 +51,6 @@ class FluxGUI(object):
 
     def run(self):
         gtk.main()
-
 
 class Indicator(object):
     """
@@ -105,11 +103,10 @@ class Indicator(object):
         self.xflux_controller.toggle_pause()
 
     def _open_preferences(self, item):
-        self.fluxgui.open_preferences()
+            self.fluxgui.open_preferences()
 
     def _quit(self, item):
         self.fluxgui.exit()
-
 
 class Preferences(object):
     """
@@ -124,6 +121,7 @@ class Preferences(object):
         if connect_target:
             widget.connect(connect_event, connect_target)
         return widget
+
 
     def __init__(self, settings, xflux_controller):
         self.settings = settings
@@ -213,7 +211,6 @@ class Preferences(object):
         self.window.hide()
         return False
 
-
 def main():
     try:
         app = FluxGUI()
@@ -224,7 +221,6 @@ def main():
         # No idea why we consistently get a keyboard interrupt here
         # after killing fluxgui with SIGINT or SIGTERM ...
         pass
-
 
 if __name__ == '__main__':
     main()

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -180,8 +180,7 @@ class Preferences(object):
         md.destroy()
 
     def preview_click_event(self, widget, data=None):
-        colsetting_temperature = settings.key_to_temperature(
-            self.colsetting.get_active())
+        colsetting_temperature = settings.key_to_temperature(self.colsetting.get_active())
         self.xflux_controller.preview_color(colsetting_temperature)
 
     def delete_event(self, widget, data=None):

--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from fluxgui.exceptions import MethodUnavailableError
 from fluxgui import fluxcontroller, settings

--- a/src/fluxgui/preferences.glade
+++ b/src/fluxgui/preferences.glade
@@ -1,315 +1,347 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy project-wide -->
-  <widget class="GtkWindow" id="window1">
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">f.lux indicator applet preferences</property>
     <property name="resizable">False</property>
     <property name="window_position">center</property>
     <child>
-      <widget class="GtkVBox" id="vbox1">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
-          <widget class="GtkTable" id="table1">
+          <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">15</property>
-            <property name="n_columns">3</property>
+            <property name="row_spacing">1</property>
             <child>
-              <widget class="GtkLabel" id="label2">
+              <object class="GtkAlignment">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">1</property>
-                <property name="ypad">10</property>
-                <property name="label" translatable="yes">ZIPCode (US only)</property>
-                <property name="single_line_mode">True</property>
-              </widget>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">5</property>
-                <property name="bottom_attach">6</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">1</property>
-                <property name="yalign">0</property>
-                <property name="ypad">10</property>
-                <property name="label" translatable="yes">Latitude</property>
-                <property name="single_line_mode">True</property>
-              </widget>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkEntry" id="entryZipcode">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Fill in your zipcode (Latitude has preference)</property>
-                <property name="activates_default">True</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-              </widget>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">5</property>
-                <property name="bottom_attach">6</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkEntry" id="entryLatitude">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Fill in your latitude</property>
-                <property name="activates_default">True</property>
-                <property name="caps_lock_warning">False</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-              </widget>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">1</property>
-                <property name="label" translatable="yes">Nighttime color temperature</property>
-                <property name="single_line_mode">True</property>
-              </widget>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">9</property>
-                <property name="bottom_attach">10</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label5">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">1</property>
-                <property name="yalign">0</property>
-                <property name="ypad">10</property>
-                <property name="label" translatable="yes">Longitude (optional)</property>
-                <property name="single_line_mode">True</property>
-              </widget>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkEntry" id="entryLongitude">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip" translatable="yes">Fill in your latitude</property>
-                <property name="activates_default">True</property>
-                <property name="caps_lock_warning">False</property>
-                <property name="primary_icon_activatable">False</property>
-                <property name="secondary_icon_activatable">False</property>
-                <property name="primary_icon_sensitive">True</property>
-                <property name="secondary_icon_sensitive">True</property>
-              </widget>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkHSeparator" id="hseparator2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </widget>
-              <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">6</property>
-                <property name="bottom_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkHSeparator" id="hseparator4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </widget>
-              <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLinkButton" id="linkbutton1">
-                <property name="label" translatable="yes">Find your latitude and longitude</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
-                <property name="relief">none</property>
-                <property name="focus_on_click">False</property>
-                <property name="uri">http://stereopsis.com/flux/map.html</property>
-                <property name="visited">True</property>
-              </widget>
-              <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_padding">10</property>
-                <property name="y_padding">5</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkLabel" id="label3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">f.lux
-Better lighting for your computer
-Copyright 2009 - 2010 Michael and Lorna Herf
-
-f.lux indicator applet made by Kilian Valkhof</property>
-                <property name="justify">center</property>
-              </widget>
-              <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">12</property>
-                <property name="bottom_attach">13</property>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkHSeparator" id="hseparator3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </widget>
-              <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <widget class="GtkHBox" id="hbox1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">10</property>
+                <property name="yalign">1</property>
+                <property name="left_padding">11</property>
+                <property name="right_padding">11</property>
                 <child>
-                  <widget class="GtkComboBox" id="comboColor">
+                  <object class="GtkEntry" id="entryLatitude">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">Fill in your latitude</property>
+                    <property name="margin_left">2</property>
+                    <property name="margin_right">5</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">5</property>
+                    <property name="max_length">3</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">1</property>
+                <property name="yalign">1</property>
+                <property name="left_padding">11</property>
+                <property name="right_padding">11</property>
+                <child>
+                  <object class="GtkEntry" id="entryLongitude">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">Fill in your longitude</property>
+                    <property name="margin_left">2</property>
+                    <property name="margin_right">5</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">5</property>
+                    <property name="max_length">3</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">1</property>
+                <property name="yalign">1</property>
+                <property name="left_padding">11</property>
+                <property name="right_padding">11</property>
+                <child>
+                  <object class="GtkEntry" id="entryZipcode">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">Fill in your zipcode (Latitude has preference)</property>
+                    <property name="margin_left">2</property>
+                    <property name="margin_right">5</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">5</property>
+                    <property name="max_length">3</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">2</property>
+                <property name="margin_right">5</property>
+                <property name="margin_top">5</property>
+                <property name="margin_bottom">5</property>
+                <property name="spacing">10</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkComboBoxText" id="comboColor">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip" translatable="yes">Fill in your preferred nighttime color temperature</property>
-                    <!-- If you change color options here you need
-                         also to change
-                         'fluxgui.settings.temperatures' accordingly
-                         -->
-                    <property name="items" translatable="yes">Min Supported By Flux (2000K)
-Dim Incandescent (2300K)
-Tungsten (2700K)
-Halogen (3400K)
-Fluorescent (4200K)
-Sunlight (5000K)</property>
-                  </widget>
+                    <property name="active_id">3</property>
+                    <items>
+                      <item id="0" translatable="yes">Min Supported by Flux  (2000K)</item>
+                      <item id="1" translatable="yes">Dim Incandescent  (2300K)</item>
+                      <item id="2" translatable="yes">Tungsten  (2700K)</item>
+                      <item id="3" translatable="yes">Halogen  (3400K)</item>
+                      <item id="4" translatable="yes">Fluorescent  (4200K)</item>
+                      <item id="5" translatable="yes">Sunlight (5000K)</item>
+                    </items>
+                  </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkButton" id="buttonPreview">
+                  <object class="GtkButton" id="buttonPreview">
                     <property name="label" translatable="yes">Preview</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip" translatable="yes">Preview the color temperature</property>
-                    <property name="use_action_appearance">False</property>
-                  </widget>
+                    <property name="margin_left">2</property>
+                    <property name="margin_right">5</property>
+                  </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
                 <property name="top_attach">9</property>
-                <property name="bottom_attach">10</property>
-                <property name="x_padding">10</property>
-                <property name="y_padding">5</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHSeparator" id="hseparator1">
+              <object class="GtkSeparator">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-              </widget>
+              </object>
               <packing>
-                <property name="right_attach">3</property>
+                <property name="left_attach">0</property>
                 <property name="top_attach">11</property>
-                <property name="bottom_attach">12</property>
-                <property name="y_padding">10</property>
+                <property name="width">3</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkCheckButton" id="checkAutostart">
-                <property name="label" translatable="yes">Autostart f.lux indicator applet</property>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">6</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">4</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">152</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="left_padding">12</property>
+                <property name="right_padding">6</property>
+                <child>
+                  <object class="GtkLabel" id="label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Latitude</property>
+                    <attributes>
+                      <attribute name="weight" value="normal"/>
+                    </attributes>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="left_padding">12</property>
+                <property name="right_padding">6</property>
+                <child>
+                  <object class="GtkLabel" id="label5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Longitude(optional)</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLinkButton" id="linkbutton1">
+                <property name="label" translatable="yes">Find your latitude and longitude</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip" translatable="yes">Start f.lux indicator applet when the computer starts</property>
-                <property name="use_action_appearance">False</property>
-                <property name="relief">none</property>
                 <property name="focus_on_click">False</property>
-                <property name="draw_indicator">True</property>
-              </widget>
+                <property name="receives_default">True</property>
+                <property name="uri">http://stereopsis.com/flux/map.html</property>
+                <property name="visited">True</property>
+              </object>
               <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">7</property>
-                <property name="bottom_attach">8</property>
-                <property name="x_padding">10</property>
-                <property name="y_padding">10</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+                <property name="width">3</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHSeparator" id="hseparator5">
+              <object class="GtkAlignment">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-              </widget>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="left_padding">12</property>
+                <property name="right_padding">6</property>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">ZIPCode (US only)</property>
+                    <property name="ellipsize">end</property>
+                    <attributes>
+                      <attribute name="weight" value="normal"/>
+                    </attributes>
+                  </object>
+                </child>
+              </object>
               <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">8</property>
-                <property name="bottom_attach">9</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">2</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHBox" id="hbox2">
+              <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Nighttime color temperature</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">9</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">5</property>
+                <property name="label" translatable="yes">f.lux
+Better lighting for your computer
+Copyright 2009 - 2010 Michael and Lorna Herf
+
+f.lux indicator applet made by Kilian Valkhof</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">12</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">13</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">2</property>
+                <property name="margin_right">5</property>
+                <property name="margin_top">5</property>
                 <child>
                   <placeholder/>
                 </child>
@@ -317,15 +349,16 @@ Sunlight (5000K)</property>
                   <placeholder/>
                 </child>
                 <child>
-                  <widget class="GtkButton" id="buttonClose">
+                  <object class="GtkButton" id="buttonClose">
                     <property name="label">gtk-close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
+                    <property name="margin_left">2</property>
+                    <property name="margin_right">5</property>
+                    <property name="margin_top">5</property>
                     <property name="use_stock">True</property>
-                    <property name="xalign">1</property>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
@@ -333,30 +366,37 @@ Sunlight (5000K)</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
-                <property name="right_attach">3</property>
+                <property name="left_attach">0</property>
                 <property name="top_attach">14</property>
-                <property name="bottom_attach">15</property>
-                <property name="x_padding">10</property>
+                <property name="width">3</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHSeparator" id="hseparator6">
+              <object class="GtkCheckButton" id="checkAutostart">
+                <property name="label" translatable="yes">	Autostart f.lux indicator applet</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </widget>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="draw_indicator">True</property>
+              </object>
               <packing>
-                <property name="right_attach">3</property>
-                <property name="top_attach">13</property>
-                <property name="bottom_attach">14</property>
-                <property name="y_padding">10</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">7</property>
+                <property name="width">3</property>
               </packing>
             </child>
             <child>
               <placeholder/>
             </child>
-          </widget>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
@@ -364,7 +404,7 @@ Sunlight (5000K)</property>
             <property name="position">0</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/src/fluxgui/preferences.glade
+++ b/src/fluxgui/preferences.glade
@@ -37,7 +37,6 @@
                     <property name="margin_right">5</property>
                     <property name="margin_top">5</property>
                     <property name="margin_bottom">5</property>
-                    <property name="max_length">3</property>
                   </object>
                 </child>
               </object>
@@ -63,7 +62,6 @@
                     <property name="margin_right">5</property>
                     <property name="margin_top">5</property>
                     <property name="margin_bottom">5</property>
-                    <property name="max_length">3</property>
                   </object>
                 </child>
               </object>
@@ -89,7 +87,6 @@
                     <property name="margin_right">5</property>
                     <property name="margin_top">5</property>
                     <property name="margin_bottom">5</property>
-                    <property name="max_length">3</property>
                   </object>
                 </child>
               </object>

--- a/src/fluxgui/preferences.glade
+++ b/src/fluxgui/preferences.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.18"/>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">f.lux indicator applet preferences</property>

--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -1,5 +1,5 @@
 import os
-import gconf
+from gi.repository import Gio
 from xdg.DesktopEntry import DesktopEntry
 from fluxgui.exceptions import DirectoryCreationError
 
@@ -13,10 +13,10 @@ from fluxgui.exceptions import DirectoryCreationError
 default_temperature = '3400'
 off_temperature = '6500'
 temperatures = [
-    '2000', # The minimum supported by flux; see https://github.com/xflux-gui/xflux-gui/issues/51
+    '2000',  # The minimum supported by flux; see https://github.com/xflux-gui/xflux-gui/issues/51
     '2300',
     '2700',
-    '3400', # The 'default_temperature' needs to be one of the options!
+    '3400',  # The 'default_temperature' needs to be one of the options!
     '4200',
     '5000',
     # The "off temperature" is not one of the menu choices, but
@@ -25,7 +25,8 @@ temperatures = [
     #
     # TODO(ntc2): understand why this entry is in the list, and remove
     # it if possible.
-    off_temperature ]
+    off_temperature]
+
 
 def key_to_temperature(key):
     """The inverse of 'temperature_to_key'.
@@ -40,6 +41,7 @@ def key_to_temperature(key):
         return temperatures[key]
     except IndexError:
         return off_temperature
+
 
 def temperature_to_key(temperature):
     """Convert a temperature like "3400" to a Glade/GTK menu value like
@@ -57,24 +59,23 @@ def temperature_to_key(temperature):
 
 ################################################################
 
+
 class Settings(object):
 
     def __init__(self):
-        # You can use 'gconftool --dump /apps/fluxgui' to see current
-        # settings on command line.
-        self.client = GConfClient("/apps/fluxgui")
+        self.settings = Gio.Settings.new('apps.fluxgui')
 
-        self._color = self.client.get_client_string("colortemp", 3400)
-        self._autostart = self.client.get_client_bool("autostart")
-        self._latitude = self.client.get_client_string("latitude")
-        self._longitude = self.client.get_client_string("longitude")
-        self._zipcode = self.client.get_client_string("zipcode")
+        self._color = self.settings.get_string("colortemp")
+        self._autostart = self.settings.get_boolean("autostart")
+        self._latitude = self.settings.get_string("latitude")
+        self._longitude = self.settings.get_string("longitude")
+        self._zipcode = self.settings.get_string("zipcode")
 
         self.has_set_prefs = True
         if not self._latitude and not self._zipcode:
             self.has_set_prefs = False
             self._zipcode = '90210'
-            self.autostart=True
+            self.autostart = True
 
         # After an upgrade to fluxgui where the color options change,
         # the color setting may no longer be one of the menu
@@ -87,56 +88,61 @@ class Settings(object):
 
     def xflux_settings_dict(self):
         d = {
-                'color': self.color,
-                'latitude': self.latitude,
-                'longitude': self.longitude,
-                'zipcode': self.zipcode,
-                'pause_color': off_temperature
+            'color': self.color,
+            'latitude': self.latitude,
+            'longitude': self.longitude,
+            'zipcode': self.zipcode,
+            'pause_color': off_temperature
         }
         return d
 
     def _get_color(self):
-        return str(self._color)
+        return self._color
+
     def _set_color(self, value):
         self._color = value
-        self.client.set_client_string("colortemp", value)
+        self.settings.set_string("colortemp", value)
 
     def _get_latitude(self):
-        return str(self._latitude)
+        return self._latitude
+
     def _set_latitude(self, value):
         self._latitude = value
-        self.client.set_client_string("latitude", value)
+        self.settings.set_string("latitude", value)
 
     def _get_longitude(self):
-        return str(self._longitude)
+        return self._longitude
+
     def _set_longitude(self, value):
         self._longitude = value
-        self.client.set_client_string("longitude", value)
+        self.settings.set_string("longitude", value)
 
     def _get_zipcode(self):
-        return str(self._zipcode)
+        return self._zipcode
+
     def _set_zipcode(self, value):
         self._zipcode = value
-        self.client.set_client_string("zipcode", value)
+        self.settings.set_string("zipcode", value)
 
     def _get_autostart(self):
-        return bool(self._autostart)
+        return self._autostart
+
     def _set_autostart(self, value):
         self._autostart = value
-        self.client.set_client_bool("autostart", self._autostart)
+        self.settings.set_boolean("autostart", self._autostart)
         if self._autostart:
             self._create_autostarter()
         else:
             self._delete_autostarter()
 
-    color=property(_get_color, _set_color)
-    latitude=property(_get_latitude, _set_latitude)
-    longitude=property(_get_longitude, _set_longitude)
-    zipcode=property(_get_zipcode, _set_zipcode)
-    autostart=property(_get_autostart, _set_autostart)
+    color = property(_get_color, _set_color)
+    latitude = property(_get_latitude, _set_latitude)
+    longitude = property(_get_longitude, _set_longitude)
+    zipcode = property(_get_zipcode, _set_zipcode)
+    autostart = property(_get_autostart, _set_autostart)
 
+    # autostart code copied from AWN
 
-    #autostart code copied from AWN
     def _get_autostart_file_path(self):
         autostart_dir = os.path.join(os.environ['HOME'], '.config',
                                      'autostart')
@@ -147,15 +153,15 @@ class Settings(object):
         autostart_dir = os.path.dirname(autostart_file)
 
         if not os.path.isdir(autostart_dir):
-            #create autostart dir
+            # create autostart dir
             try:
                 os.mkdir(autostart_dir)
-            except DirectoryCreationError, e:
-                print "Creation of autostart dir failed, please make it yourself: %s" % autostart_dir
+            except DirectoryCreationError as e:
+                print("Creation of autostart dir failed, please make it yourself: {}".format(autostart_dir))
                 raise e
 
         if not os.path.isfile(autostart_file):
-            #create autostart entry
+            # create autostart entry
             starter_item = DesktopEntry(autostart_file)
             starter_item.set('Name', 'f.lux indicator applet')
             # Use the user's shell to start 'fluxgui', in case
@@ -183,51 +189,3 @@ class Settings(object):
         if os.path.isfile(autostart_file):
             os.remove(autostart_file)
             self.autostart = False
-
-class GConfClient(object):
-    """
-    Gets and sets gconf settings.
-    """
-
-    def __init__(self, prefs_key):
-        self.client = gconf.client_get_default()
-        self.prefs_key = prefs_key
-        self.client.add_dir(self.prefs_key, gconf.CLIENT_PRELOAD_NONE)
-
-    def get_client_string(self, property_name, default=""):
-        client_string = self.client.get_string(self.prefs_key+"/"+property_name)
-        if client_string is None:
-            client_string = default
-        return client_string
-
-    def set_client_string(self, property_name, value):
-        self.client.set_string(self.prefs_key + "/" + property_name, str(value))
-
-    def get_client_bool(self, property_name, default=True):
-        try:
-            gconf_type = self.client.get(self.prefs_key + "/"
-                                            + property_name).type
-        except AttributeError:
-            # key is not set
-            self.set_client_bool(property_name, default)
-            client_bool = default
-            return client_bool
-
-        client_bool = None
-        if gconf_type != gconf.VALUE_BOOL:
-            # previous release used strings for autostart, handle here
-            client_string = self.get_client_string(property_name).lower()
-            if client_string == '1':
-                self.set_client_bool(property_name, True)
-                client_bool = True
-            elif client_string == '0':
-                self.set_client_bool(property_name, False)
-                client_bool = False
-        else:
-            client_bool = self.client.get_bool(self.prefs_key
-                                        + "/"+property_name)
-        return client_bool
-
-    def set_client_bool(self, property_name, value):
-        self.client.set_bool(self.prefs_key + "/" + property_name, bool(value))
-

--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -13,10 +13,10 @@ from fluxgui.exceptions import DirectoryCreationError
 default_temperature = '3400'
 off_temperature = '6500'
 temperatures = [
-    '2000',  # The minimum supported by flux; see https://github.com/xflux-gui/xflux-gui/issues/51
+    '2000', # The minimum supported by flux; see https://github.com/xflux-gui/xflux-gui/issues/51
     '2300',
     '2700',
-    '3400',  # The 'default_temperature' needs to be one of the options!
+    '3400', # The 'default_temperature' needs to be one of the options!
     '4200',
     '5000',
     # The "off temperature" is not one of the menu choices, but
@@ -25,8 +25,7 @@ temperatures = [
     #
     # TODO(ntc2): understand why this entry is in the list, and remove
     # it if possible.
-    off_temperature]
-
+    off_temperature ]
 
 def key_to_temperature(key):
     """The inverse of 'temperature_to_key'.
@@ -41,7 +40,6 @@ def key_to_temperature(key):
         return temperatures[key]
     except IndexError:
         return off_temperature
-
 
 def temperature_to_key(temperature):
     """Convert a temperature like "3400" to a Glade/GTK menu value like
@@ -58,7 +56,6 @@ def temperature_to_key(temperature):
     return len(temperatures) - 1
 
 ################################################################
-
 
 class Settings(object):
 
@@ -135,14 +132,14 @@ class Settings(object):
         else:
             self._delete_autostarter()
 
-    color = property(_get_color, _set_color)
-    latitude = property(_get_latitude, _set_latitude)
-    longitude = property(_get_longitude, _set_longitude)
-    zipcode = property(_get_zipcode, _set_zipcode)
-    autostart = property(_get_autostart, _set_autostart)
+    color=property(_get_color, _set_color)
+    latitude=property(_get_latitude, _set_latitude)
+    longitude=property(_get_longitude, _set_longitude)
+    zipcode=property(_get_zipcode, _set_zipcode)
+    autostart=property(_get_autostart, _set_autostart)
 
-    # autostart code copied from AWN
 
+    #autostart code copied from AWN
     def _get_autostart_file_path(self):
         autostart_dir = os.path.join(os.environ['HOME'], '.config',
                                      'autostart')
@@ -153,7 +150,7 @@ class Settings(object):
         autostart_dir = os.path.dirname(autostart_file)
 
         if not os.path.isdir(autostart_dir):
-            # create autostart dir
+            #create autostart dir
             try:
                 os.mkdir(autostart_dir)
             except DirectoryCreationError as e:

--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -60,6 +60,14 @@ def temperature_to_key(temperature):
 class Settings(object):
 
     def __init__(self):
+        # You can use
+        #
+        #     gsettings [--schema-dir .] list-recursively apps.fluxgui
+        #
+        # to see current settings on command line. The '--schema-dir'
+        # is necessary if you're using a non-standard schema dir,
+        # e.g. when running fluxgui from the repo without installing
+        # it.
         self.settings = Gio.Settings.new('apps.fluxgui')
 
         self._color = self.settings.get_string("colortemp")

--- a/src/fluxgui/settings.py
+++ b/src/fluxgui/settings.py
@@ -88,11 +88,11 @@ class Settings(object):
 
     def xflux_settings_dict(self):
         d = {
-            'color': self.color,
-            'latitude': self.latitude,
-            'longitude': self.longitude,
-            'zipcode': self.zipcode,
-            'pause_color': off_temperature
+                'color': self.color,
+                'latitude': self.latitude,
+                'longitude': self.longitude,
+                'zipcode': self.zipcode,
+                'pause_color': off_temperature
         }
         return d
 

--- a/src/fluxgui/xfluxcontroller.py
+++ b/src/fluxgui/xfluxcontroller.py
@@ -59,14 +59,14 @@ class XfluxController(object):
             color = self._xflux.after[10:14]
         return color
 
-    color=property(_get_xflux_color, _set_xflux_color)
+    color = property(_get_xflux_color, _set_xflux_color)
 
     def _start(self, startup_args=None):
         if not startup_args:
             startup_args = self._create_startup_arg_list(self._current_color,
                 **self.init_kwargs)
         try:
-            previous_instances = pexpect.run('pgrep -d, -u %s xflux' % pexpect.run('whoami')).strip()
+            previous_instances = pexpect.run('pgrep -d, -u {} xflux'.format(pexpect.run('whoami'))).strip()
             if previous_instances != "":
                 for process in previous_instances.split(","):
                     pexpect.run('kill -9 %s' % process)
@@ -87,14 +87,14 @@ class XfluxController(object):
             # means 'kill -9' ...
             time.sleep(1)
         except Exception as e:
-            print 'XfluxController._stop: unexpected exception when resetting color:'
-            print e
+            print('XfluxController._stop: unexpected exception when resetting color:')
+            print(e)
         try:
             return self._xflux.terminate(force=True)
         except Exception:
             # xflux has crashed in the meantime?
-            print 'XfluxController._stop: unexpected exception when terminating xflux:'
-            print e
+            print('XfluxController._stop: unexpected exception when terminating xflux:')
+            print(e)
             return True
 
     def _preview_color(self, preview_color, return_color):
@@ -163,7 +163,7 @@ class XfluxController(object):
     def _set_xflux_screen_color(self, color):
         # use _set_xflux_color unless keeping
         # self._current_color the same is necessary
-        self._xflux.sendline("k="+str(color))
+        self._xflux.sendline("k={}".format(str(color)))
 
 
 class _XfluxState(object):

--- a/src/fluxgui/xfluxcontroller.py
+++ b/src/fluxgui/xfluxcontroller.py
@@ -1,18 +1,19 @@
 import pexpect
 import time
 import weakref
-from fluxgui.exceptions import *
+from fluxgui.exceptions import XfluxError, MethodUnavailableError
 from fluxgui import settings
+
 
 class XfluxController(object):
     """
     A controller that starts and interacts with an xflux process.
     """
 
-    def __init__(self, color=settings.default_temperature, pause_color=settings.off_temperature, **kwargs):
+    def __init__(self, color=settings.default_temperature, pause_color=settings.off_temperature,
+                 **kwargs):
         if 'zipcode' not in kwargs and 'latitude' not in kwargs:
-            raise XfluxError(
-                    "Required key not found (either zipcode or latitude)")
+            raise XfluxError("Required key not found (either zipcode or latitude)")
         if 'longitude' not in kwargs:
             kwargs['longitude'] = 0
         self.init_kwargs = kwargs
@@ -64,19 +65,19 @@ class XfluxController(object):
     def _start(self, startup_args=None):
         if not startup_args:
             startup_args = self._create_startup_arg_list(self._current_color,
-                **self.init_kwargs)
+                                                         **self.init_kwargs)
         try:
             previous_instances = pexpect.run('pgrep -d, -u {} xflux'.format(pexpect.run('whoami'))).strip()
             if previous_instances != "":
                 for process in previous_instances.split(","):
                     pexpect.run('kill -9 %s' % process)
-                   
+
             self._xflux = pexpect.spawn("xflux", startup_args)
-                    #logfile=file("tmp/xfluxout.txt",'w'))
+            # logfile=file("tmp/xfluxout.txt",'w'))
 
         except pexpect.ExceptionPexpect:
             raise FileNotFoundError(
-                    "\nError: Please install xflux in the PATH \n")
+                "\nError: Please install xflux in the PATH \n")
 
     def _stop(self):
         try:
@@ -91,7 +92,7 @@ class XfluxController(object):
             print(e)
         try:
             return self._xflux.terminate(force=True)
-        except Exception:
+        except Exception as e:
             # xflux has crashed in the meantime?
             print('XfluxController._stop: unexpected exception when terminating xflux:')
             print(e)
@@ -109,10 +110,10 @@ class XfluxController(object):
         self._change_color_immediately(return_color)
 
     _settings_map = {
-            'latitude':'l=',
-            'longitude':'g=',
-            'zipcode':'z=',
-            'color':'k=',
+        'latitude': 'l=',
+        'longitude': 'g=',
+        'zipcode': 'z=',
+        'color': 'k=',
     }
 
     def _set_xflux_setting(self, **kwargs):
@@ -126,7 +127,7 @@ class XfluxController(object):
                     if self.state == self.states["PAUSED"]:
                         self.state = self.states["RUNNING"]
                 else:
-                    self._xflux.sendline(self._settings_map[key]+str(value))
+                    self._xflux.sendline(self._settings_map[key] + str(value))
                 self._c()
 
     def _create_startup_arg_list(self, color='3400', **kwargs):
@@ -138,7 +139,7 @@ class XfluxController(object):
             startup_args += ["-l", str(kwargs["latitude"])]
         if "longitude" in kwargs and kwargs['longitude']:
             startup_args += ["-g", str(kwargs["longitude"])]
-        startup_args += ["-k", str(color), "-nofork"] # nofork is vital
+        startup_args += ["-k", str(color), "-nofork"]  # nofork is vital
 
         return startup_args
 
@@ -171,61 +172,77 @@ class _XfluxState(object):
 
     def __init__(self, controller_instance):
         self.controller_ref = weakref.ref(controller_instance)
+
     def start(self, startup_args):
         raise MethodUnavailableError(
-                "Xflux cannot start in its current state")
+            "Xflux cannot start in its current state")
+
     def stop(self):
         raise MethodUnavailableError(
-                "Xflux cannot stop in its current state")
+            "Xflux cannot stop in its current state")
+
     def preview(self, preview_color):
         raise MethodUnavailableError(
-                "Xflux cannot preview in its current state")
+            "Xflux cannot preview in its current state")
+
     def toggle_pause(self):
         raise MethodUnavailableError(
-                "Xflux cannot pause/unpause in its current state")
+            "Xflux cannot pause/unpause in its current state")
+
     def set_setting(self, **kwargs):
         raise MethodUnavailableError(
-                "Xflux cannot alter settings in its current state")
+            "Xflux cannot alter settings in its current state")
+
 
 class _InitState(_XfluxState):
     def start(self, startup_args):
         self.controller_ref()._start(startup_args)
         self.controller_ref().state = self.controller_ref().states["RUNNING"]
+
     def stop(self):
         return True
+
     def set_setting(self, **kwargs):
         for key, value in kwargs.items():
             self.controller_ref().init_kwargs[key] = str(value)
+
 
 class _TerminatedState(_XfluxState):
     def stop(self):
         return True
 
+
 class _AliveState(_XfluxState):
     can_change_settings = True
+
     def stop(self):
         success = self.controller_ref()._stop()
         if success:
             self.controller_ref().state = \
                 self.controller_ref().states["TERMINATED"]
         return success
+
     def set_setting(self, **kwargs):
         self.controller_ref()._set_xflux_setting(**kwargs)
+
 
 class _RunningState(_AliveState):
     def toggle_pause(self):
         self.controller_ref()._change_color_immediately(
-                self.controller_ref()._pause_color)
+            self.controller_ref()._pause_color)
         self.controller_ref().state = self.controller_ref().states["PAUSED"]
+
     def preview(self, preview_color):
         self.controller_ref()._preview_color(preview_color,
-                self.controller_ref()._current_color)
+                                             self.controller_ref()._current_color)
+
 
 class _PauseState(_AliveState):
     def toggle_pause(self):
         self.controller_ref()._change_color_immediately(
-                self.controller_ref()._current_color)
+            self.controller_ref()._current_color)
         self.controller_ref().state = self.controller_ref().states["RUNNING"]
+
     def preview(self, preview_color):
         self.controller_ref()._preview_color(preview_color,
-                self.controller_ref()._pause_color)
+                                             self.controller_ref()._pause_color)

--- a/src/fluxgui/xfluxcontroller.py
+++ b/src/fluxgui/xfluxcontroller.py
@@ -67,17 +67,18 @@ class XfluxController(object):
             startup_args = self._create_startup_arg_list(self._current_color,
                                                          **self.init_kwargs)
         try:
-            previous_instances = pexpect.run('pgrep -d, -u {} xflux'.format(pexpect.run('whoami'))).strip()
+            user_name = pexpect.run('whoami').decode('utf-8').strip()
+            command = 'pgrep -d, -u {} xflux'.format(user_name)
+            previous_instances = pexpect.run(command).strip().decode('utf-8')
             if previous_instances != "":
                 for process in previous_instances.split(","):
-                    pexpect.run('kill -9 %s' % process)
+                    pexpect.run('kill -9 {}'.format(process))
 
             self._xflux = pexpect.spawn("xflux", startup_args)
             # logfile=file("tmp/xfluxout.txt",'w'))
 
         except pexpect.ExceptionPexpect:
-            raise FileNotFoundError(
-                "\nError: Please install xflux in the PATH \n")
+            raise FileNotFoundError("\nError: Please install xflux in the PATH \n")
 
     def _stop(self):
         try:

--- a/src/fluxgui/xfluxcontroller.py
+++ b/src/fluxgui/xfluxcontroller.py
@@ -10,10 +10,10 @@ class XfluxController(object):
     A controller that starts and interacts with an xflux process.
     """
 
-    def __init__(self, color=settings.default_temperature, pause_color=settings.off_temperature,
-                 **kwargs):
+    def __init__(self, color=settings.default_temperature, pause_color=settings.off_temperature, **kwargs):
         if 'zipcode' not in kwargs and 'latitude' not in kwargs:
-            raise XfluxError("Required key not found (either zipcode or latitude)")
+            raise XfluxError(
+                    "Required key not found (either zipcode or latitude)")
         if 'longitude' not in kwargs:
             kwargs['longitude'] = 0
         self.init_kwargs = kwargs
@@ -65,7 +65,7 @@ class XfluxController(object):
     def _start(self, startup_args=None):
         if not startup_args:
             startup_args = self._create_startup_arg_list(self._current_color,
-                                                         **self.init_kwargs)
+                **self.init_kwargs)
         try:
             user_name = pexpect.run('whoami').decode('utf-8').strip()
             command = 'pgrep -d, -u {} xflux'.format(user_name)
@@ -78,7 +78,8 @@ class XfluxController(object):
             # logfile=file("tmp/xfluxout.txt",'w'))
 
         except pexpect.ExceptionPexpect:
-            raise FileNotFoundError("\nError: Please install xflux in the PATH \n")
+            raise FileNotFoundError(
+                    "\nError: Please install xflux in the PATH \n")
 
     def _stop(self):
         try:
@@ -111,10 +112,10 @@ class XfluxController(object):
         self._change_color_immediately(return_color)
 
     _settings_map = {
-        'latitude': 'l=',
-        'longitude': 'g=',
-        'zipcode': 'z=',
-        'color': 'k=',
+             'latitude': 'l=',
+             'longitude': 'g=',
+             'zipcode': 'z=',
+             'color': 'k=',
     }
 
     def _set_xflux_setting(self, **kwargs):
@@ -176,23 +177,23 @@ class _XfluxState(object):
 
     def start(self, startup_args):
         raise MethodUnavailableError(
-            "Xflux cannot start in its current state")
+                "Xflux cannot start in its current state")
 
     def stop(self):
         raise MethodUnavailableError(
-            "Xflux cannot stop in its current state")
+                "Xflux cannot stop in its current state")
 
     def preview(self, preview_color):
         raise MethodUnavailableError(
-            "Xflux cannot preview in its current state")
+                "Xflux cannot preview in its current state")
 
     def toggle_pause(self):
         raise MethodUnavailableError(
-            "Xflux cannot pause/unpause in its current state")
+                "Xflux cannot pause/unpause in its current state")
 
     def set_setting(self, **kwargs):
         raise MethodUnavailableError(
-            "Xflux cannot alter settings in its current state")
+                "Xflux cannot alter settings in its current state")
 
 
 class _InitState(_XfluxState):
@@ -230,20 +231,20 @@ class _AliveState(_XfluxState):
 class _RunningState(_AliveState):
     def toggle_pause(self):
         self.controller_ref()._change_color_immediately(
-            self.controller_ref()._pause_color)
+                self.controller_ref()._pause_color)
         self.controller_ref().state = self.controller_ref().states["PAUSED"]
 
     def preview(self, preview_color):
         self.controller_ref()._preview_color(preview_color,
-                                             self.controller_ref()._current_color)
+                self.controller_ref()._current_color)
 
 
 class _PauseState(_AliveState):
     def toggle_pause(self):
         self.controller_ref()._change_color_immediately(
-            self.controller_ref()._current_color)
+                self.controller_ref()._current_color)
         self.controller_ref().state = self.controller_ref().states["RUNNING"]
 
     def preview(self, preview_color):
         self.controller_ref()._preview_color(preview_color,
-                                             self.controller_ref()._pause_color)
+                self.controller_ref()._pause_color)


### PR DESCRIPTION
More discussion in Issue #111.

# TODO

- [ ] Update Apt deps in README
  - Ubuntu 16.04:
    - `gir1.2-appindicator3-0.1` or `libappindicator3-dev`, altho the second one has a million deps
- [ ] Update Apt deps in Debian package description
- [x] Update manual install instructions in README
- [x] Change GTK3 version bound in https://github.com/LaBatata101/fluxgui-py3/blob/6313936cd67374b7d424d862f1609d6427ea9cad/src/fluxgui/preferences.glade#L4 to get this working on Ubuntu 16.04
- [x] Update `setup.py` to install `apps.fluxgui.gschema.xml` and compile schemas with `glib-compile-schemas`.
- [x] Figure out why I get the wrong icon (wrong theme) on 18.04. I get the right icon on 16.04: just a bug in the 16.04 -> 18.04 upgrade process: opening `gnome-tweaks`, changing my icon theme, and then changing it back, fixed the problem.