### PR TITLE
INTERNAL Fixed an error during start on the Fedora 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo apt-get install git python-appindicator python-xdg python-pexpect python-gc
 WARNING: these dependencies may be out of date after the uprgrade to GTK+ 3 in PR #112. If you discover the correct deps, please submit a PR.
 
 ```bash
-sudo yum install git python-appindicator python2-pyxdg python2-pexpect gnome-python2-gconf pygtk2 pygtk2-libglade
+sudo yum install git python-appindicator python2-pyxdg python3-pexpect gnome-python2-gconf pygtk2 pygtk2-libglade
 ```
 
 #### Install `fluxgui`


### PR DESCRIPTION
Thanks for the tool!

Environment: Fedora 29
Dependencies: sudo yum install git python-appindicator python2-pyxdg python3-pexpect gnome-python2-gconf pygtk2 pygtk2-libglade

> fluxgui
Traceback (most recent call last):
  File "/home/eugeneroldukhin/.local/bin/fluxgui", line 17, in <module>
    from fluxgui.fluxapp import main
  File "/home/eugeneroldukhin/.local/lib/python3.7/site-packages/fluxgui/fluxapp.py", line 4, in <module>
    from fluxgui import fluxcontroller, settings
  File "/home/eugeneroldukhin/.local/lib/python3.7/site-packages/fluxgui/fluxcontroller.py", line 1, in <module>
    from fluxgui import xfluxcontroller
  File "/home/eugeneroldukhin/.local/lib/python3.7/site-packages/fluxgui/xfluxcontroller.py", line 1, in <module>
    import pexpect
ModuleNotFoundError: No module named 'pexpect'

We need the change dependency and use pexpect3 for python3.
