### PR TITLE
setup.py: add posbility to disable compilation of gschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,10 @@ class install_data(distutils.command.install_data.install_data):
         super().run()
 
         # Compile '*.gschema.xml' to update or create 'gschemas.compiled'.
-        info("compiling gsettings schemas")
-        gschema_dir = os.path.join(self.install_dir, gschema_dir_suffix)
-        self.spawn(["glib-compile-schemas", gschema_dir])
+        if os.environ.get('DISABLE_GSCHEMAS_COMPILED', None) is None:
+            info("compiling gsettings schemas")
+            gschema_dir = os.path.join(self.install_dir, gschema_dir_suffix)
+            self.spawn(["glib-compile-schemas", gschema_dir])
 
 setup(name = "f.lux indicator applet",
     version = "1.2.1~pre",


### PR DESCRIPTION
When you install fluxgui, it also compiles the gschema, which is for
most distros fine. But on source distros like Gentoo, which do the
compilation of gschema separately, this will lead to a file collision,
as packages unter Gentoo are not allowed to install such files.

So we introduce a new env variable called DISABLE_GSCHEMA_COMPILED which
needs to be set to disable this behaviour.

Closes: https://github.com/xflux-gui/fluxgui/issues/124
Signed-off-by: Conrad Kostecki <conrad@kostecki.com>