### PR TITLE
Fix Python warnings

### DIFF
--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -146,7 +146,7 @@ class Preferences(object):
                 self.delete_event, "clicked")
         self.autostart = self.connect_widget("checkAutostart")
 
-        if (self.settings.latitude is "" and self.settings.zipcode is "")\
+        if (self.settings.latitude == "" and self.settings.zipcode == "")\
                 or not self.settings.has_set_prefs:
             self.show()
             self.display_no_zipcode_or_latitude_error_box()


### PR DESCRIPTION
Two repeated warnings of the form:

```
/usr/lib/python3/dist-packages/fluxgui/fluxapp.py:149: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

These warnings appear when using Python 3.8.2.