### PR TITLE
Update fluxapp.py

### DIFF
--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -6,8 +6,8 @@ import sys
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk as gtk
-gi.require_version('AppIndicator3', '0.1')
-from gi.repository import AppIndicator3 as appindicator
+gi.require_version('AyatanaAppIndicator3', '0.1')
+from gi.repository import AyatanaAppIndicator3 as appindicator
 from fluxgui.exceptions import MethodUnavailableError
 from fluxgui import fluxcontroller, settings
 


### PR DESCRIPTION
Making fluxgui up-to-date with current development version of Debian. 
AyatanaAppindicator packages are are straighforward replacement in Debian for unmaintaind Appindicator packages.
Other than this, fluxgui needs no redshit, since redshift also does not work under wayland.
Fluxgui/xflux works perfectly under X11. Those errors are from trying to run fluxgui under wayland, which requires compositor level implementation of color temperature changing.
Fluxgui/xflux are awesome.