### PR TITLE
Update control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Package: fluxgui
 Architecture: all
 Multi-Arch: foreign
 Depends: ${xflux:Depends}, ${misc:Depends}, ${python3:Depends}, wget, ca-certificates,
- python3-pexpect, gir1.2-appindicator3-0.1, python3-gi, python3-xdg
+ python3-pexpect, gir1.2-ayatanaappindicator3-0.1, python3-gi, python3-xdg
 Description: f.lux indicator applet is an indicator applet to control xflux, an
  application that makes the color of your computer's display adapt to the time
  of day, warm at nights and like sunlight during the day


### PR DESCRIPTION
With this dependency change to gir1.2-ayatanaappindicator3-0.1, basic Debian package build and install is possible in conjunction with my previous patch.  Further refinements (distro version, etc.) would make it even more acceptable for Debian based distributions.
This application fluxgui/xflux runs perfectly still in X11 based sessions and it integrates perfectly into modern desktop system trays (KDE/GNOME/XFCE).
P.S. python-support (>=0.8.7) build-dep is not available in Debian sid, but dh-python is.  So no problem whatsoever.